### PR TITLE
Upgrade shiny app and asset env to ubuntu 20.04

### DIFF
--- a/Tutorials/bash/r-shiny-web-app/dxapp.json
+++ b/Tutorials/bash/r-shiny-web-app/dxapp.json
@@ -14,12 +14,13 @@
       }
     },
     "interpreter": "bash",
-    "release": "16.04",
+    "release": "20.04",
+    "version": "0",
     "distribution": "Ubuntu",
     "file": "src/code.sh",
     "assetDepends": [
       {
-        "id": "record-FX4ZV100JfBVQJV71fP12QpB"
+        "id": "record-G1181xj00V7b07V3J82bzYj9"
       }
     ]
   },

--- a/Tutorials/bash/shiny-asset/dxasset.json
+++ b/Tutorials/bash/shiny-asset/dxasset.json
@@ -4,7 +4,7 @@
     "description": "Libraries for building web apps with R Shiny",
     "version": "0.0.1",
     "distribution": "Ubuntu",
-    "release": "16.04",
+    "release": "20.04",
     "execDepends": [
         {"name": "shiny", "package_manager": "cran"}
     ]


### PR DESCRIPTION
16.04 no longer works.